### PR TITLE
Implement basic marketplace pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import SidebarRight from '@/components/sidebar-right/sidebar-right';
 import ThemePanel from '@/components/theme-panel/theme-panel';
 import { AppSettingsProvider, useAppSettings } from '@/config/app-settings';
 
-function Layout({ children }: { children: React.ReactNode }) {
+export function Layout({ children }: { children: React.ReactNode }) {
   const { settings } = useAppSettings();
   
   const handleScroll = useCallback(() => {

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,0 +1,40 @@
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@fortawesome/fontawesome-free/css/all.css';
+import 'react-perfect-scrollbar/dist/css/styles.css';
+import '@/styles/nextjs.scss';
+
+import { AppSettingsProvider } from '@/config/app-settings';
+import { Layout } from '@/app/layout';
+import { useEffect } from 'react';
+
+function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    let isMounted = true;
+    const loadBootstrap = async () => {
+      try {
+        const bootstrap = await import('bootstrap');
+        if (isMounted) {
+          window.bootstrap = bootstrap;
+        }
+      } catch (err) {
+        console.error('Error loading Bootstrap:', err);
+      }
+    };
+    if (typeof window !== 'undefined') {
+      loadBootstrap();
+    }
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <AppSettingsProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </AppSettingsProvider>
+  );
+}
+
+export default MyApp;

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import api from '@/services/api';
+
+export default function DashboardPage() {
+  const [wallet, setWallet] = useState(null);
+  const [properties, setProperties] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [walletRes, propRes] = await Promise.all([
+          api.get('/wallet'),
+          api.get('/properties'),
+        ]);
+        setWallet(walletRes.data);
+        setProperties(propRes.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Dashboard</h1>
+      {wallet && (
+        <div className="mb-6">
+          <h2 className="text-lg">Saldo: R$ {wallet.balance}</h2>
+        </div>
+      )}
+      <h2 className="text-xl mb-2">Imóveis</h2>
+      <ul className="space-y-2">
+        {properties.map((prop) => (
+          <li key={prop.id} className="border p-4 rounded">
+            <div className="font-bold">{prop.name}</div>
+            <Link href={`/imoveis/${prop.id}`} className="text-blue-500">
+              Ver detalhes
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/imoveis/[id].js
+++ b/src/pages/imoveis/[id].js
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import api from '@/services/api';
+
+export default function ImovelPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [property, setProperty] = useState(null);
+  const [amount, setAmount] = useState(1);
+
+  useEffect(() => {
+    if (id) {
+      api.get(`/properties/${id}`).then((res) => setProperty(res.data));
+    }
+  }, [id]);
+
+  const handlePurchase = async () => {
+    try {
+      await api.post('/investments/purchase', { property_id: id, amount });
+      alert('Compra realizada!');
+    } catch (error) {
+      console.error(error);
+      alert('Erro na compra');
+    }
+  };
+
+  if (!property) return <div className="p-4">Carregando...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">{property.name}</h1>
+      <p className="mb-4">{property.description}</p>
+      <div className="space-y-2">
+        <input
+          type="number"
+          min="1"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="border p-2"
+        />
+        <button
+          onClick={handlePurchase}
+          className="bg-green-500 text-white px-4 py-2"
+        >
+          Comprar Tokens
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import api from '@/services/api';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const { data } = await api.post('/auth/investor-login', { email, password });
+      if (data.token) {
+        localStorage.setItem('token', data.token);
+        router.push('/dashboard');
+      }
+    } catch (error) {
+      console.error(error);
+      setError('Falha no login');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-2xl mb-4">Login</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          className="border p-2 w-full"
+          placeholder="E-mail"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-2 w-full"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
+          Entrar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/investimentos.js
+++ b/src/pages/investimentos.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import api from '@/services/api';
+
+export default function InvestimentosPage() {
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    api.get('/investments/history').then((res) => setHistory(res.data || []));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Histórico de Investimentos</h1>
+      <ul className="space-y-2">
+        {history.map((item) => (
+          <li key={item.id} className="border p-4 rounded">
+            <p>Imóvel: {item.property?.name}</p>
+            <p>Quantidade: {item.amount}</p>
+            <p>Valor: {item.total_price}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/p2p/nova.js
+++ b/src/pages/p2p/nova.js
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import api from '@/services/api';
+
+export default function NovaOfertaPage() {
+  const router = useRouter();
+  const [propertyId, setPropertyId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [price, setPrice] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/p2p/listings', {
+        property_id: propertyId,
+        amount,
+        price,
+      });
+      router.push('/p2p/ofertas');
+    } catch (error) {
+      console.error(error);
+      alert('Erro ao criar oferta');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-2xl mb-4">Nova Oferta</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="border p-2 w-full"
+          placeholder="ID do Imóvel"
+          value={propertyId}
+          onChange={(e) => setPropertyId(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Quantidade de tokens"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Preço por token"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
+          Criar Oferta
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api',
+});
+
+api.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- expose `Layout` component for reuse
- configure axios instance with JWT interceptor
- wrap `pages` routes with existing layout via custom `_app`
- add login, dashboard, property detail, investment history and P2P listing pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685746c238348328b59b18320f4b80a3