### PR TITLE
Implement basic marketplace pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import SidebarRight from '@/components/sidebar-right/sidebar-right';
 import ThemePanel from '@/components/theme-panel/theme-panel';
 import { AppSettingsProvider, useAppSettings } from '@/config/app-settings';
 
-function Layout({ children }: { children: React.ReactNode }) {
+export function Layout({ children }: { children: React.ReactNode }) {
   const { settings } = useAppSettings();
   
   const handleScroll = useCallback(() => {

--- a/src/app/user/login-v3/page.tsx
+++ b/src/app/user/login-v3/page.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useEffect, FormEvent } from 'react';
-import { redirect } from 'next/navigation';
+import { useEffect, FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useAppSettings } from '@/config/app-settings';
 import Link from 'next/link';
+import api from '@/services/api';
 
 export default function LoginV1() {
-	const { updateSettings } = useAppSettings();
+        const { updateSettings } = useAppSettings();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
 	
 	useEffect(() => {
 		updateSettings({
@@ -26,10 +31,21 @@ export default function LoginV1() {
 		// eslint-disable-next-line
 	}, []);
 	
-	function handleSubmit(event: FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-		
-  	redirect('/');
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      const { data } = await api.post('/auth/investor-login', {
+        email,
+        password,
+      });
+      if (data.token) {
+        localStorage.setItem('token', data.token);
+        router.push('/dashboard');
+      }
+    } catch (err) {
+      console.error(err);
+      setError('Falha no login');
+    }
   }
   
 	return (
@@ -58,12 +74,27 @@ export default function LoginV1() {
         </div>
         <div className="login-content">
           <form onSubmit={handleSubmit} className="fs-13px">
+            {error && <div className="text-danger mb-2">{error}</div>}
             <div className="form-floating mb-15px">
-              <input type="text" className="form-control h-45px fs-13px" placeholder="Email Address" id="emailAddress" />
+              <input
+                type="email"
+                className="form-control h-45px fs-13px"
+                placeholder="Email Address"
+                id="emailAddress"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
               <label htmlFor="emailAddress" className="d-flex align-items-center fs-13px text-gray-600">Email Address</label>
             </div>
             <div className="form-floating mb-15px">
-              <input type="password" className="form-control h-45px fs-13px" placeholder="Password" id="password" />
+              <input
+                type="password"
+                className="form-control h-45px fs-13px"
+                placeholder="Password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
               <label htmlFor="password" className="d-flex align-items-center fs-13px text-gray-600">Password</label>
             </div>
             <div className="form-check mb-30px">

--- a/src/app/user/register-v3/page.tsx
+++ b/src/app/user/register-v3/page.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { useEffect, FormEvent } from 'react';
-import { redirect } from 'next/navigation';
+import { useEffect, FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useAppSettings } from '@/config/app-settings';
 import Link from 'next/link';
+import api from '@/services/api';
 
 export default function LoginV1() {
-	const { updateSettings } = useAppSettings();
+        const { updateSettings } = useAppSettings();
+  const router = useRouter();
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
 	
 	useEffect(() => {
 		updateSettings({
@@ -26,10 +33,25 @@ export default function LoginV1() {
 		// eslint-disable-next-line
 	}, []);
 	
-	function handleSubmit(event: FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-		
-  	redirect('/');
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      const { data } = await api.post('/auth/register', {
+        first_name: firstName,
+        last_name: lastName,
+        email,
+        password,
+      });
+      if (data.token) {
+        localStorage.setItem('token', data.token);
+        router.push('/dashboard');
+      } else {
+        router.push('/user/login-v3');
+      }
+    } catch (err) {
+      console.error(err);
+      setError('Falha no registro');
+    }
   }
   
 	return (
@@ -50,20 +72,39 @@ export default function LoginV1() {
         </div>
         <div className="register-content">
           <form onSubmit={handleSubmit} className="fs-13px">
+            {error && <div className="text-danger mb-2">{error}</div>}
             <div className="mb-3">
               <label className="mb-2">Name <span className="text-danger">*</span></label>
               <div className="row gx-3">
                 <div className="col-md-6 mb-2 mb-md-0">
-                  <input type="text" className="form-control fs-13px" placeholder="First name" />
+                  <input
+                    type="text"
+                    className="form-control fs-13px"
+                    placeholder="First name"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                  />
                 </div>
                 <div className="col-md-6">
-                  <input type="text" className="form-control fs-13px" placeholder="Last name" />
+                  <input
+                    type="text"
+                    className="form-control fs-13px"
+                    placeholder="Last name"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                  />
                 </div>
               </div>
             </div>
             <div className="mb-3">
               <label className="mb-2">Email <span className="text-danger">*</span></label>
-              <input type="text" className="form-control fs-13px" placeholder="Email address" />
+              <input
+                type="email"
+                className="form-control fs-13px"
+                placeholder="Email address"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
             </div>
             <div className="mb-3">
               <label className="mb-2">Re-enter Email <span className="text-danger">*</span></label>
@@ -71,7 +112,13 @@ export default function LoginV1() {
             </div>
             <div className="mb-4">
               <label className="mb-2">Password <span className="text-danger">*</span></label>
-              <input type="password" className="form-control fs-13px" placeholder="Password" />
+              <input
+                type="password"
+                className="form-control fs-13px"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
             </div>
             <div className="form-check mb-4">
               <input className="form-check-input" type="checkbox" value="" id="agreementCheckbox" />

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,0 +1,40 @@
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@fortawesome/fontawesome-free/css/all.css';
+import 'react-perfect-scrollbar/dist/css/styles.css';
+import '@/styles/nextjs.scss';
+
+import { AppSettingsProvider } from '@/config/app-settings';
+import { Layout } from '@/app/layout';
+import { useEffect } from 'react';
+
+function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    let isMounted = true;
+    const loadBootstrap = async () => {
+      try {
+        const bootstrap = await import('bootstrap');
+        if (isMounted) {
+          window.bootstrap = bootstrap;
+        }
+      } catch (err) {
+        console.error('Error loading Bootstrap:', err);
+      }
+    };
+    if (typeof window !== 'undefined') {
+      loadBootstrap();
+    }
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <AppSettingsProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </AppSettingsProvider>
+  );
+}
+
+export default MyApp;

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import api from '@/services/api';
+
+export default function DashboardPage() {
+  const [wallet, setWallet] = useState(null);
+  const [properties, setProperties] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [walletRes, propRes] = await Promise.all([
+          api.get('/wallet'),
+          api.get('/properties'),
+        ]);
+        setWallet(walletRes.data);
+        setProperties(propRes.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Dashboard</h1>
+      {wallet && (
+        <div className="mb-6">
+          <h2 className="text-lg">Saldo: R$ {wallet.balance}</h2>
+        </div>
+      )}
+      <h2 className="text-xl mb-2">Imóveis</h2>
+      <ul className="space-y-2">
+        {properties.map((prop) => (
+          <li key={prop.id} className="border p-4 rounded">
+            <div className="font-bold">{prop.name}</div>
+            <Link href={`/imoveis/${prop.id}`} className="text-blue-500">
+              Ver detalhes
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/imoveis/[id].js
+++ b/src/pages/imoveis/[id].js
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import api from '@/services/api';
+
+export default function ImovelPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [property, setProperty] = useState(null);
+  const [amount, setAmount] = useState(1);
+
+  useEffect(() => {
+    if (id) {
+      api.get(`/properties/${id}`).then((res) => setProperty(res.data));
+    }
+  }, [id]);
+
+  const handlePurchase = async () => {
+    try {
+      await api.post('/investments/purchase', { property_id: id, amount });
+      alert('Compra realizada!');
+    } catch (error) {
+      console.error(error);
+      alert('Erro na compra');
+    }
+  };
+
+  if (!property) return <div className="p-4">Carregando...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">{property.name}</h1>
+      <p className="mb-4">{property.description}</p>
+      <div className="space-y-2">
+        <input
+          type="number"
+          min="1"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="border p-2"
+        />
+        <button
+          onClick={handlePurchase}
+          className="bg-green-500 text-white px-4 py-2"
+        >
+          Comprar Tokens
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Home() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/user/login-v3');
+  }, [router]);
+
+  return null;
+}

--- a/src/pages/investimentos.js
+++ b/src/pages/investimentos.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import api from '@/services/api';
+
+export default function InvestimentosPage() {
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    api.get('/investments/history').then((res) => setHistory(res.data || []));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Histórico de Investimentos</h1>
+      <ul className="space-y-2">
+        {history.map((item) => (
+          <li key={item.id} className="border p-4 rounded">
+            <p>Imóvel: {item.property?.name}</p>
+            <p>Quantidade: {item.amount}</p>
+            <p>Valor: {item.total_price}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/p2p/nova.js
+++ b/src/pages/p2p/nova.js
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import api from '@/services/api';
+
+export default function NovaOfertaPage() {
+  const router = useRouter();
+  const [propertyId, setPropertyId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [price, setPrice] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/p2p/listings', {
+        property_id: propertyId,
+        amount,
+        price,
+      });
+      router.push('/p2p/ofertas');
+    } catch (error) {
+      console.error(error);
+      alert('Erro ao criar oferta');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-2xl mb-4">Nova Oferta</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="border p-2 w-full"
+          placeholder="ID do Imóvel"
+          value={propertyId}
+          onChange={(e) => setPropertyId(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Quantidade de tokens"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Preço por token"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
+          Criar Oferta
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api',
+});
+
+api.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- expose `Layout` component for reuse
- configure axios instance with JWT interceptor
- wrap `pages` routes with existing layout via custom `_app`
- add login, dashboard, property detail, investment history and P2P listing pages
- use existing login & register templates with working API calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685746c238348328b59b18320f4b80a3